### PR TITLE
Fixed UAA

### DIFF
--- a/entries/UAA.yml
+++ b/entries/UAA.yml
@@ -1,6 +1,6 @@
 ---
 headword: UAA
-expansion: Universal Account and Authentication
+expansion: User Account and Authentication
 definition: UAA is the component of a CF deployment responsible for user authentication
   and authorization. It acts as an identity proxy by integrating with external identity
   providers (e.g. Okta, Centrify, Ping Identity, etc) and exposing an OAuth interface


### PR DESCRIPTION
It's User not Universal in UAA!

If Pivotal have decide to change the meaning then we'll need to update loads of docs and the open-source project. E.g.

http://docs.cloudfoundry.org/api/uaa/version/4.11.0/#overview