### PR TITLE
Add "SI" as a related word

### DIFF
--- a/entries/AI.yml
+++ b/entries/AI.yml
@@ -7,4 +7,4 @@ definition: >
   the more likely they are to renew their subscription.
 links:
 see_also:
-
+- SI


### PR DESCRIPTION
In the Field Gate app where we see customer consumptions of our software, AI consumption and SI consumption are listed side by side.