### PR TITLE
PASW corrections + PASW 2012R2

### DIFF
--- a/entries/PASW 2012R2.yml
+++ b/entries/PASW 2012R2.yml
@@ -1,0 +1,8 @@
+---
+headword: PASW 2012R2
+expansion: PAS for Windows 2012R2
+definition: >
+  Pivotal Application Service for Windows 2012R2 (formerly known as PCF Runtime for Windows) gives developers the ability to push applications powered by the .NET Framework, the Windows® Server 2012 R2 operating system, and IronFrame containerization framework.
+links:
+- https://network.pivotal.io/products/p-windows-runtime
+see_also:

--- a/entries/PASW.yml
+++ b/entries/PASW.yml
@@ -2,10 +2,8 @@
 headword: PASW
 expansion: PAS for Windows
 definition: >
-  Pivotal Application Service for Windows (formerly known as PCF Runtime for Windows) gives developers the
-  ability to push applications powered by the .NET Framework, the Windows® Server 2012 R2 operating system, and
-  IronFrame containerization framework.
+  Pivotal Application Service for Windows is a complete, scalable runtime environment that enables developers to host applications powered by the .NET Framework, the Windows® Server 2016 operating system, and Windows Server Containers.
 links:
-- https://network.pivotal.io/products/p-windows-runtime
+- https://network.pivotal.io/products/pas-windows
 - https://pivotal.io/platform/pcf-components/pas-for-windows
 see_also:


### PR DESCRIPTION
There are two Windows-based products; the current description conflates the descriptions between the two. I've provided the corrected description for PASW and added the older product PASW 2012R2.