### PR TITLE
IaaS instead of IAAS

### DIFF
--- a/entries/IAAS.yml
+++ b/entries/IAAS.yml
@@ -1,5 +1,5 @@
 ---
-headword: IAAS
+headword: IaaS
 expansion: Infrastructure as a Service
 definition: >
   Managing the physical computer hardware necessary to run workloads is a costly and difficult business. As a result, 


### PR DESCRIPTION
The heading was inconsistent with the body text. I believe that IaaS is the recommended capitalization.