### PR TITLE
Update APJ.yml

### DIFF
--- a/entries/APJ.yml
+++ b/entries/APJ.yml
@@ -1,6 +1,6 @@
 ---
 headword: APJ
-expansion: Asia-Pacific
+expansion: Asia-Pacific and Japan
 definition: Pivotal's global support team is divided into different regions AMER, EMEA, and APJ to better serve the customers in those areas.
 links:
 - https://en.wikipedia.org/wiki/Asia-Pacific


### PR DESCRIPTION
I think Japan should be included in this definition. This may sound weird. Japan actually in AP but it would like be mentioned as individually. Pivotal may follow this convention from EMC or VMWare.